### PR TITLE
Added visitOrigin for Safari browsing history

### DIFF
--- a/js/app/chrome.js
+++ b/js/app/chrome.js
@@ -2,7 +2,7 @@
 chrome.browserAction.onClicked.addListener(function(tab) {
 	//Look to see if the extension page is open already and if not, open it.
 
-	var optionsUrl = chrome.extension.getURL('index.html');
+	var optionsUrl = chrome.runtime.getURL('index.html');
 
 	chrome.tabs.query({}, function(extensionTabs) {
 		var found = false;

--- a/js/app/database.js
+++ b/js/app/database.js
@@ -100,6 +100,10 @@ define(["moment", "app/config", "core/utils", "jquery"], function(moment, config
 			unique: false 
 		});
 
+		visitObjectStore.createIndex("visitOrigin", "visitOrigin", { // The 'visitOrigin' is only available on Safari. For other browsers, this is ignored.
+			unique: false 
+		});
+
 
 		var categoryObjectStore = db.createObjectStore("categories", { 
 			autoIncrement:true 
@@ -615,8 +619,10 @@ define(["moment", "app/config", "core/utils", "jquery"], function(moment, config
                                 "transType": cursor.value['transition'],
                                 "date": cursor.value['visitTime'],
                                 "id": cursor.value['id'],
-                                "visitId": cursor.value['visitId'],
-                                "domain": cursor.value['domain']
+                                "visitId": cursor.value['visitId']
+                            };
+                            if ("visitOrigin" in cursor.value) { // The 'visitOrigin' is only available on Safari. For other browsers, this will not be appended.
+                                visit["visitOrigin"] = cursor.value['visitOrigin'];
                             };
                             
                             bundle.push(visit);

--- a/js/app/websites-data-table.js
+++ b/js/app/websites-data-table.js
@@ -46,10 +46,10 @@ define(["core/utils", "app/config", "core/database", "moment", "d3-context-menu"
 			var recordsRev = utils.sortByPropRev(records, 'visitTime');
 			if (domName==null) {
 				recordsFilter = recordsRev;
-				$("#panel_title").html(chrome.i18n.getMessage("wdtPanelTitl1"));
+				$("#panel_title").html(chrome.i18n.getMessage("wdtPanelTitle1"));
 			} else {
 				recordsFilter = utils.onlyIf(recordsRev, 'domain', domName, false);
-				$("#panel_title").html(chrome.i18n.getMessage("wdtPanelTitl2") + domName);
+				$("#panel_title").html(chrome.i18n.getMessage("wdtPanelTitle2") + domName);
 			}
 			for (var i = 0; i < recordsFilter.length; i++) {
 				dataSet.push({


### PR DESCRIPTION
The 'origin' entry in the Safari browsing history indicates on which device the URL was accessed. With this commit, the 'origin' data is also transferred to the Passive Data Kit. For Chrome or other browsers, the entry is simply ignored.